### PR TITLE
Folder name differs from lib name, updated setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,5 +56,5 @@ setup(
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    packages=['adafruit_charlcd'],
+    packages=['adafruit_character_lcd'],
 )


### PR DESCRIPTION
I think this will fix the issue with travis deploying the app. The folder name containing all the packages is different from the lib name, which isn't the case in any other repo, so I didn't think to check for it. Noted for future reference.