### PR TITLE
Add backlight inversion option (Fixes #5)

### DIFF
--- a/adafruit_character_lcd/character_lcd.py
+++ b/adafruit_character_lcd/character_lcd.py
@@ -165,7 +165,11 @@ class Character_LCD(object):
         #  Setup backlight
         if backlight is not None:
             self.backlight.direction = digitalio.Direction.OUTPUT
-            self.backlight.value = 0 # turn backlight on
+            if backlight.inverted is not None:
+                self.backlight.inverted = backlight.inverted
+            else:
+                self.backlight.inverted = True
+            self.set_backlight(True, self.backlight.inverted)
         #  initialize the display
         self._write8(0x33)
         self._write8(0x32)
@@ -298,14 +302,14 @@ class Character_LCD(object):
         self.enable.value = False
         time.sleep(0.0000001)
 
-    def set_backlight(self, lighton):
+    def set_backlight(self, lighton, inverted=True):
         """
         Set lighton to turn the charLCD backlight on.
 
         :param lighton: True to turn backlight on, False to turn off
 
         """
-        if lighton:
+        if (lighton and inverted) or (lightoff and not inverted):
             self.backlight.value = 0
         else:
             self.backlight.value = 1

--- a/adafruit_character_lcd/character_lcd.py
+++ b/adafruit_character_lcd/character_lcd.py
@@ -309,7 +309,7 @@ class Character_LCD(object):
         :param lighton: True to turn backlight on, False to turn off
 
         """
-        if (lighton and inverted) or (lightoff and not inverted):
+        if (lighton and inverted) or (not lighton and not inverted):
             self.backlight.value = 0
         else:
             self.backlight.value = 1

--- a/adafruit_character_lcd/character_lcd_rgb.py
+++ b/adafruit_character_lcd/character_lcd_rgb.py
@@ -152,7 +152,11 @@ class Character_LCD_RGB:
         # setup backlight
         if backlight is not None:
             self.backlight.direction = digitalio.Direction.OUTPUT
-            self.backlight.value = 0 # turn backlight on
+        if backlight.inverted is not None:
+            self.backlight.inverted = backlight.inverted
+        else:
+            self.backlight.inverted = True
+        self.set_backlight(True, self.backlight.inverted)
 
         # define color params
         self.red = red
@@ -260,11 +264,12 @@ class Character_LCD_RGB:
         self.enable.value = False
         time.sleep(0.0000001)
 
-    def set_backlight(self, lighton):
-        """ Set lighton to turn the charLCD backlight on.
-            :param lighton: True to turn backlight on, False to turn off
+    def set_backlight(self, lighton, inverted=True):
         """
-        if lighton:
+        Set lighton to turn the charLCD backlight on.
+        :param lighton: True to turn backlight on, False to turn off
+        """
+        if (lighton and inverted) or (not lighton and not inverted):
             self.backlight.value = 0
         else:
             self.backlight.value = 1


### PR DESCRIPTION
I saw this issue going through @kattni's library status issue and it looked like a quick fix so I jumped in. The new API lets you add an inverted field to the backlight object used in the constructor, and also lets you specify in the set_backlight method. In both cases it defaults to True, the old behaviour, so this should be a non-breaking API change.