### PR TITLE
cursor_position fix, add column check

### DIFF
--- a/adafruit_character_lcd/character_lcd.py
+++ b/adafruit_character_lcd/character_lcd.py
@@ -236,8 +236,11 @@ class Character_LCD:
             :param row: row location
         """
         # Clamp row to the last row of the display
-        if row > self.lines:
+        if row >= self.lines:
             row = self.lines - 1
+        # Clamp to last column of display
+        if column >= self.columns:
+            column = self.columns - 1
         # Set location
         self._write8(_LCD_SETDDRAMADDR | (column + _LCD_ROW_OFFSETS[row]))
 


### PR DESCRIPTION
If you set the coordinate column or line in `cursor_position` to the same number as the number of columns or lines in the initialisation of the display, it would move the cursor off of the display. This fixes that issue.

Also added a check to keep the cursor on the screen if the number provides for the column coordinate is outside the number of columns.