### PR TITLE
Add I2C address parameter

### DIFF
--- a/adafruit_character_lcd/character_lcd_i2c.py
+++ b/adafruit_character_lcd/character_lcd_i2c.py
@@ -66,13 +66,16 @@ class Character_LCD_I2C(Character_LCD_Mono):
         i2c = busio.I2C(board.SCL, board.SDA)
         lcd = Character_LCD_I2C(i2c, 16, 2)
     """
-    def __init__(self, i2c, columns, lines, backlight_inverted=False):
+    def __init__(self, i2c, columns, lines, address=None, backlight_inverted=False):
         """Initialize character LCD connected to backpack using I2C connection
         on the specified I2C bus with the specified number of columns and
         lines on the display. Optionally specify if backlight is inverted.
         """
         from adafruit_mcp230xx.mcp23008 import MCP23008
-        mcp = MCP23008(i2c)
+        if address:
+            mcp = MCP23008(i2c, address=address)
+        else:
+            mcp = MCP23008(i2c)
         super().__init__(mcp.get_pin(1),
                          mcp.get_pin(2),
                          mcp.get_pin(3),

--- a/adafruit_character_lcd/character_lcd_i2c.py
+++ b/adafruit_character_lcd/character_lcd_i2c.py
@@ -50,7 +50,7 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_CharLCD.git"
 
 
 class Character_LCD_I2C(Character_LCD_Mono):
-    # pylint: disable=too-few-public-methods
+    # pylint: disable=too-few-public-methods, too-many-arguments
     """Character LCD connected to I2C/SPI backpack using its I2C connection.
     This is a subclass of Character_LCD and implements all of the same
     functions and functionality.

--- a/adafruit_character_lcd/character_lcd_rgb_i2c.py
+++ b/adafruit_character_lcd/character_lcd_rgb_i2c.py
@@ -77,14 +77,17 @@ class Character_LCD_RGB_I2C(Character_LCD_RGB):
         lcd = Character_LCD_RGB_I2C(i2c, 16, 2)
 
     """
-    def __init__(self, i2c, columns, lines):
+    def __init__(self, i2c, columns, lines, address=None):
         # pylint: disable=too-many-locals
         """Initialize RGB character LCD connected to shield using I2C connection
         on the specified I2C bus with the specified number of columns and lines
         on the display.
         """
         from adafruit_mcp230xx.mcp23017 import MCP23017
-        mcp = MCP23017(i2c)
+        if address:
+            mcp = MCP23017(i2c, address=address)
+        else:
+            mcp = MCP23017(i2c)
 
         self._left_button = mcp.get_pin(4)
         self._up_button = mcp.get_pin(3)


### PR DESCRIPTION
For #38 

Don't have a Pi Plate to test and the Shield doesn't look like it can change address. But did test Shield with default and it still works (no photo).

Tested with Backpack set to 0x21 and one line change in `charlcd_i2c_mono_simpletest.py`:
```python
lcd = character_lcd.Character_LCD_I2C(i2c, lcd_columns, lcd_rows, address=0x21)
```
![lcd_i2c_test](https://user-images.githubusercontent.com/8755041/72575547-a2b61500-3881-11ea-8c6a-d0c83908ab70.jpg)
