### PR TITLE
remove bad-whitespace pylint directive

### DIFF
--- a/adafruit_character_lcd/character_lcd.py
+++ b/adafruit_character_lcd/character_lcd.py
@@ -52,7 +52,6 @@ from micropython import const
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_CharLCD.git"
 
-# pylint: disable-msg=bad-whitespace
 # Commands
 _LCD_CLEARDISPLAY = const(0x01)
 _LCD_RETURNHOME = const(0x02)
@@ -88,7 +87,6 @@ _LCD_5X8DOTS = const(0x00)
 # Offset for up to 4 rows.
 _LCD_ROW_OFFSETS = (0x00, 0x40, 0x14, 0x54)
 
-# pylint: enable-msg=bad-whitespace
 
 
 def _set_bit(byte_value, position, val):

--- a/adafruit_character_lcd/character_lcd.py
+++ b/adafruit_character_lcd/character_lcd.py
@@ -88,7 +88,6 @@ _LCD_5X8DOTS = const(0x00)
 _LCD_ROW_OFFSETS = (0x00, 0x40, 0x14, 0x54)
 
 
-
 def _set_bit(byte_value, position, val):
     # Given the specified byte_value set the bit at position to the provided
     # boolean value val and return the modified byte.


### PR DESCRIPTION
This directive has been removed from pylint 2.6.0.