### PR TITLE
Update charlcd_rpi_rgb_simpletest.py

### DIFF
--- a/examples/charlcd_rpi_rgb_simpletest.py
+++ b/examples/charlcd_rpi_rgb_simpletest.py
@@ -9,19 +9,20 @@ lcd_columns = 16
 lcd_rows = 2
 
 # Raspberry Pi Pin Config:
-lcd_rs = digitalio.DigitalInOut(board.D26)  # pin 4
-lcd_en = digitalio.DigitalInOut(board.D19)  # pin 6
-lcd_d7 = digitalio.DigitalInOut(board.D27)  # pin 14
-lcd_d6 = digitalio.DigitalInOut(board.D22)  # pin 13
-lcd_d5 = digitalio.DigitalInOut(board.D24)  # pin 12
-lcd_d4 = digitalio.DigitalInOut(board.D25)  # pin 11
-lcd_backlight = digitalio.DigitalInOut(board.D4)
+lcd_rs = digitalio.DigitalInOut(board.D26)  # LCD pin 4
+lcd_en = digitalio.DigitalInOut(board.D19)  # LCD pin 6
+lcd_d7 = digitalio.DigitalInOut(board.D27)  # LCD pin 14
+lcd_d6 = digitalio.DigitalInOut(board.D22)  # LCD pin 13
+lcd_d5 = digitalio.DigitalInOut(board.D24)  # LCD pin 12
+lcd_d4 = digitalio.DigitalInOut(board.D25)  # LCD pin 11
+lcd_rw = digitalio.DigitalInOut(board.D4)   # LCD pin 5.  Determines whether to read to or write from the display. Not necessary if only writing to the display. Used on shield.
 
 red = digitalio.DigitalInOut(board.D21)
 green = digitalio.DigitalInOut(board.D12)
 blue = digitalio.DigitalInOut(board.D18)
 
-# Initialise the LCD class
+# Initialize the LCD class
+# The lcd_rw parameter is optional.  You can omit the line below if you're only writing to the display.
 lcd = characterlcd.Character_LCD_RGB(
     lcd_rs,
     lcd_en,
@@ -34,7 +35,7 @@ lcd = characterlcd.Character_LCD_RGB(
     red,
     green,
     blue,
-    lcd_backlight,
+    lcd_rw,
 )
 
 RED = [1, 0, 0]

--- a/examples/charlcd_rpi_rgb_simpletest.py
+++ b/examples/charlcd_rpi_rgb_simpletest.py
@@ -18,14 +18,16 @@ lcd_d5 = digitalio.DigitalInOut(board.D24)  # LCD pin 12
 lcd_d4 = digitalio.DigitalInOut(board.D25)  # LCD pin 11
 lcd_rw = digitalio.DigitalInOut(
     board.D4
-)  # LCD pin 5.  Determines whether to read to or write from the display. Not necessary if only writing to the display. Used on shield.
+)  # LCD pin 5.  Determines whether to read to or write from the display.
+# Not necessary if only writing to the display. Used on shield.
 
 red = pulseio.PWMOut(board.D21)
 green = pulseio.PWMOut(board.D12)
 blue = pulseio.PWMOut(board.D18)
 
 # Initialize the LCD class
-# The lcd_rw parameter is optional.  You can omit the line below if you're only writing to the display.
+# The lcd_rw parameter is optional.  You can omit the line below if you're only
+# writing to the display.
 lcd = characterlcd.Character_LCD_RGB(
     lcd_rs,
     lcd_en,

--- a/examples/charlcd_rpi_rgb_simpletest.py
+++ b/examples/charlcd_rpi_rgb_simpletest.py
@@ -16,7 +16,9 @@ lcd_d7 = digitalio.DigitalInOut(board.D27)  # LCD pin 14
 lcd_d6 = digitalio.DigitalInOut(board.D22)  # LCD pin 13
 lcd_d5 = digitalio.DigitalInOut(board.D24)  # LCD pin 12
 lcd_d4 = digitalio.DigitalInOut(board.D25)  # LCD pin 11
-lcd_rw = digitalio.DigitalInOut(board.D4)   # LCD pin 5.  Determines whether to read to or write from the display. Not necessary if only writing to the display. Used on shield.
+lcd_rw = digitalio.DigitalInOut(
+    board.D4
+)  # LCD pin 5.  Determines whether to read to or write from the display. Not necessary if only writing to the display. Used on shield.
 
 red = pulseio.PWMOut(board.D21)
 green = pulseio.PWMOut(board.D12)


### PR DESCRIPTION
-When initializing the class, the last parameter is for the RW feature, however, the previous version of code said it was the lcd_backlight.  Renamed it to lcd_rw.
-Renamed the comment spelling from Initialise to Initialize.
-Changed the comments from "# pin 4" (for example)  to "# LCD pin 4" to let the user know we're talking about the LCD pin, not a Pi BOARD/BCM association.